### PR TITLE
cmake: Must use '--no-as-needed' linker flag for indirect dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ find_package(NEXUS REQUIRED)
 find_package(NXCLIENT REQUIRED)
 find_package(NexusPlayready REQUIRED)
 
+string(REPLACE "-Wl,--as-needed" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-as-needed")
+
 add_library(${DRM_PLUGIN_NAME} SHARED 
     MediaSession.cpp
     MediaSystem.cpp


### PR DESCRIPTION
The Playready library has some indirect library dependencies (e.g. to
'libdrmrootfs.so') that need to be made explicit when linking it to this
plugin's library, i.e., it is this plugin's library that must make these
dependencies explicit. Otherwise, there are runtime errors about
undefined symbols.

The logic in 'FindNexusPlayready.cmake' is correct for finding the
dependencies, but then because cmake by default uses the '--as-needed'
linker flag, the indirect dependencies get linked out. This way, make
sure that '--as-needed' is replaced with '--no-as-needed' in the linker
flags.

Same procedure had already to be applied in other plugins for similar
cases, so just reuse that logic.

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>